### PR TITLE
Fix video playback issues in Safari

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,7 +2,12 @@
 
 require_relative "config/environment"
 
-use Rack::Deflater
+use Rack::Deflater, if: lambda { |_env, _status, headers, _body|
+  # If videos are compressed and served via Cloudflare, the HTTP Range requests return a wrong status code
+  # (200 OK instead of the correct 206 Partial Content). This causes Safari playback issues.
+  !headers.key?(Rack::CONTENT_TYPE) || !headers[Rack::CONTENT_TYPE].to_s.start_with?("video/")
+}
+
 run Rails.application
 
 Rails.application.load_server

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,5 @@ module Campfire
 
     # Use SQL schema format to include search-related objects
     config.active_record.schema_format = :sql
-
-    config.middleware.insert_after ActionDispatch::Static, Rack::Deflater
   end
 end


### PR DESCRIPTION
Turns out Cloudflare doesn't like when the original server compresses videos. This causes an incorrect 200 OK response instead of the correct 206 Partial Content to HTTP Range requests.

I fixed this issue by conditionally disabling the `Rack::Deflater`compression only for videos.

I was able to:
- Find the original server IP behind Cloudflare
- Confirm that bypassing Cloudflare (via `/etc/hosts`) fixes the issue
- Reproduce the issue locally (via Cloudflare tunnel to my local machine)
- Confirm that turning off the compression for videos fixes the issue

Related thread with some ideas that guided me to a functional solution: https://community.cloudflare.com/t/mp4-wont-load-in-safari-using-cloudflare/10587/55

Fixes https://github.com/antiwork/smallbets/issues/41