### PR TITLE
Pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/deploy_with_kamal.yml
+++ b/.github/workflows/deploy_with_kamal.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0  # Fetch all history for git operations
 
       - name: Get short SHA
-        uses: benjlevesque/short-sha@v3.0
+        uses: benjlevesque/short-sha@599815c8ee942a9616c92bcfb4f947a3b670ab0b # v3.0
         id: short-sha
         with:
           length: 7
@@ -45,7 +45,7 @@ jobs:
         run: gem install kamal
 
       - name: Set up SSH key
-        uses: webfactory/ssh-agent@v0.8.0
+        uses: webfactory/ssh-agent@d4b9b8ff72958532804b70bbe600ad43b36d5f2e # v0.8.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 


### PR DESCRIPTION
GitHub [recommends](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions) pinning third-party Actions to commit SHAs instead of versions, which are just Git tags/branches and can introduce a supply-chain attack.

I didn't pin the Ruby one, since we assume it to be "trusted" (and want to keep the version up to date), but if you think we should pin it as well, will do.