### PR TITLE
Optimize sidebar loading with skeleton UI and reduced DOM complexity

### DIFF
--- a/app/helpers/users/sidebar_helper.rb
+++ b/app/helpers/users/sidebar_helper.rb
@@ -5,13 +5,19 @@ module Users::SidebarHelper
     Current.user.memberships.unread.any?
   end
 
-  def sidebar_turbo_frame_tag(src: nil, &)
+  def sidebar_turbo_frame_tag(src: nil, &block)
     turbo_frame_tag :user_sidebar, src: src, target: "_top", data: {
       turbo_permanent: true,
       controller: "rooms-list read-rooms turbo-frame",
       rooms_list_unread_class: "unread",
       rooms_list_badge_class: "badge",
       action: "presence:present@window->rooms-list#read read-rooms:read->rooms-list#read turbo:frame-load->rooms-list#loaded refresh-room:visible@window->turbo-frame#reload".html_safe # otherwise -> is escaped
-    }, &
+    } do
+      if src.present? && block.nil?
+        render "users/sidebars/loading"
+      elsif block
+        capture(&block)
+      end
+    end
   end
 end

--- a/app/views/users/sidebars/_loading.html.erb
+++ b/app/views/users/sidebars/_loading.html.erb
@@ -1,0 +1,26 @@
+<div class="sidebar__container overflow-y overflow-hide-scrollbar" style="padding: var(--inline-space);">
+  <div style="display: flex; flex-direction: column; gap: var(--block-space);">
+    <div style="height: 60px; background: var(--color-border); border-radius: 8px; opacity: 0.3; animation: pulse 1.5s ease-in-out infinite;"></div>
+    
+    <div style="display: flex; flex-direction: column; gap: calc(var(--block-space) / 2); margin-block-start: var(--block-space);">
+      <div style="height: 20px; width: 100px; background: var(--color-border); border-radius: 4px; opacity: 0.3; animation: pulse 1.5s ease-in-out infinite;"></div>
+      <% 8.times do %>
+        <div style="height: 40px; background: var(--color-border); border-radius: 6px; opacity: 0.3; animation: pulse 1.5s ease-in-out infinite; animation-delay: <%= rand(0..300) %>ms;"></div>
+      <% end %>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: calc(var(--block-space) / 2); margin-block-start: var(--block-space);">
+      <div style="height: 20px; width: 120px; background: var(--color-border); border-radius: 4px; opacity: 0.3; animation: pulse 1.5s ease-in-out infinite;"></div>
+      <% 12.times do %>
+        <div style="height: 40px; background: var(--color-border); border-radius: 6px; opacity: 0.3; animation: pulse 1.5s ease-in-out infinite; animation-delay: <%= rand(0..300) %>ms;"></div>
+      <% end %>
+    </div>
+  </div>
+
+  <style>
+    @keyframes pulse {
+      0%, 100% { opacity: 0.3; }
+      50% { opacity: 0.15; }
+    }
+  </style>
+</div>

--- a/app/views/users/sidebars/rooms/_shared.html.erb
+++ b/app/views/users/sidebars/rooms/_shared.html.erb
@@ -4,24 +4,18 @@
 <% has_notifications = local_assigns[:membership]&.has_unread_notifications? %>
 
 <div id="<%= dom_id(room, dom_prefix(list_name, :list_node)) %>" data-sorted-list-target="item"
-     data-name="<%= room.sortable_name %>" data-search-text="<%= room.sortable_name %>" data-size="<%= room.messages_count %>"
+     data-name="<%= room.sortable_name %>" data-search-text="<%= room.sortable_name %>"
      data-updated-at="<%= room.last_active_at.iso8601 %>"
      data-sidebar-starred-rooms-target="room" data-involvement="<%= involvement %>"
-     data-type="list_node"
      class="flex gap align-center justify-space-between">
     <%= link_to_room room,
-                     class: [ "flex flex-item-grow gap align-center justify-space-between room full-height txt-nowrap overflow-ellipsis txt-lighter txt-undecorated pad-block position-relative", "unread": unread, "badge": has_notifications ],
-                     style: "padding-block: calc(var(--block-space) / 4);" do %>
-      <span class="overflow-ellipsis"><%= room_display_name(room) %></span>
-
-      <hr class="separator flex-item-grow" aria-hidden="true">
-
-      <%= local_datetime_tag room.last_active_at, style: :relative, class: "txt-x-small txt-primary txt-nowrap position-relative" %>
+                     class: [ "flex flex-item-grow room txt-nowrap overflow-ellipsis txt-lighter txt-undecorated position-relative", "unread": unread, "badge": has_notifications ],
+                     style: "padding-block: calc(var(--block-space) / 4); gap: 0.5rem;" do %>
+      <span class="overflow-ellipsis" style="flex: 0 1 auto;"><%= room_display_name(room) %></span>
+      <span style="flex: 1 1 0; min-width: 1rem;" aria-hidden="true"></span>
+      <%= local_datetime_tag room.last_active_at, style: :relative, class: "txt-x-small txt-primary txt-nowrap" %>
     <% end %>
-
-    <span class="txt-small">
-      <%= turbo_frame_tag dom_id(room, dom_prefix(:sidebar, :involvement)) do %>
-        <%= button_to_change_involvement(room, involvement, from_sidebar: true) %>
-      <% end %>
-    </span>
+    <%= turbo_frame_tag dom_id(room, dom_prefix(:sidebar, :involvement)), loading: :lazy, class: "txt-small" do %>
+      <%= button_to_change_involvement(room, involvement, from_sidebar: true) %>
+    <% end %>
 </div>


### PR DESCRIPTION
  - Add loading skeleton UI for sidebar to improve perceived performance
  - Reduce DOM complexity in room list items by removing unnecessary elements
  - Lazy-load involvement buttons to defer non-critical rendering