### PR TITLE
fix: login screen email input field

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -22,7 +22,7 @@
           <div class="flex align-center gap">
             <%= translation_button(:email_address) %>
             <label class="flex align-center gap input input--actor txt-large">
-              <%= form.email_field :email_address, required: true, class: "input", autofocus: true, autocomplete: "email", placeholder: "Enter your email address", value: params[:email_address] %>
+              <%= form.email_field :email_address, required: true, class: "input", autofocus: true, autocomplete: "email", placeholder: "Enter your email addre..", value: params[:email_address] %>
               <%= image_tag "email.svg", role: "presentation", size: 24, class: "colorize--black" %>
             </label>
           </div>


### PR DESCRIPTION
## Description 
fixes the email input field's placeholder 

### Before
<img width="509" height="733" alt="image" src="https://github.com/user-attachments/assets/58c74e1d-d55e-4805-87d5-2baedc935824" />


### After 
<img width="509" height="733" alt="image" src="https://github.com/user-attachments/assets/35c4babe-a04d-41f1-a646-69f91c8d7784" />
