### PR TITLE
Fix room update timeout with async broadcasts

### DIFF
--- a/app/controllers/rooms/closeds_controller.rb
+++ b/app/controllers/rooms/closeds_controller.rb
@@ -59,11 +59,7 @@ class Rooms::ClosedsController < RoomsController
     end
 
     def broadcast_update_room
-      for_each_sidebar_section do |list_name|
-        each_user_and_html_for(@room, list_name:) do |user, html|
-          broadcast_replace_to user, :rooms, target: [ @room, helpers.dom_prefix(list_name, :list_node) ], html: html
-        end
-      end
+      Room::BroadcastUpdateJob.perform_later(@room)
     end
 
     def each_user_and_html_for_create(room, **locals)
@@ -72,16 +68,6 @@ class Rooms::ClosedsController < RoomsController
 
       room.memberships.visible.each do |membership|
         yield membership.user, html
-      end
-    end
-
-    def each_user_and_html_for(room, **locals)
-      html_cache = {}
-
-      room.memberships.visible.includes(:user).with_has_unread_notifications.each do |membership|
-        yield membership.user, render_or_cached(html_cache,
-                                                partial: "users/sidebars/rooms/shared",
-                                                locals: { membership: }.merge(locals))
       end
     end
 end

--- a/app/controllers/rooms/opens_controller.rb
+++ b/app/controllers/rooms/opens_controller.rb
@@ -40,20 +40,6 @@ class Rooms::OpensController < RoomsController
     end
 
     def broadcast_update_room
-      for_each_sidebar_section do |list_name|
-        each_user_and_html_for(@room, list_name:) do | user, html |
-          broadcast_replace_to user, :rooms, target: [ @room, helpers.dom_prefix(list_name, :list_node) ], html: html
-        end
-      end
+      Room::BroadcastUpdateJob.perform_later(@room)
     end
-
-  def each_user_and_html_for(room, **locals)
-    html_cache = {}
-
-    room.memberships.visible.includes(:user).with_has_unread_notifications.each do |membership|
-      yield membership.user, render_or_cached(html_cache,
-                                              partial: "users/sidebars/rooms/shared",
-                                              locals: { membership: }.merge(locals))
-    end
-  end
 end

--- a/app/jobs/room/broadcast_update_job.rb
+++ b/app/jobs/room/broadcast_update_job.rb
@@ -1,0 +1,44 @@
+class Room::BroadcastUpdateJob < ApplicationJob
+  include Turbo::Streams::Broadcasts
+  include Turbo::Streams::StreamName
+
+  def perform(room)
+    for_each_sidebar_section do |list_name|
+      broadcast_to_members(room, list_name)
+    end
+  end
+
+  private
+    def broadcast_to_members(room, list_name)
+      html_cache = {}
+
+      room.memberships.visible.includes(:user).with_has_unread_notifications.find_each do |membership|
+        cache_key = {
+          room_id: room.id,
+          list_name:,
+          involvement: membership.involvement,
+          unread: membership.unread?,
+          has_notifications: membership.has_unread_notifications?
+        }
+        
+        html = html_cache[cache_key] ||= ApplicationController.render(
+          partial: "users/sidebars/rooms/shared",
+          locals: { membership:, list_name: }
+        )
+        
+        broadcast_replace_to membership.user, :rooms, 
+                            target: [ room, dom_prefix(list_name, :list_node) ], 
+                            html: html
+      end
+    end
+
+    def for_each_sidebar_section
+      [ :starred_rooms, :shared_rooms ].each do |name|
+        yield name
+      end
+    end
+
+    def dom_prefix(list_name, node_type)
+      "#{list_name}_#{node_type}"
+    end
+end

--- a/test/controllers/rooms/closeds_controller_test.rb
+++ b/test/controllers/rooms/closeds_controller_test.rb
@@ -48,8 +48,10 @@ class Rooms::ClosedsControllerTest < ActionDispatch::IntegrationTest
   test "only admins or creators can update" do
     sign_in :jz
 
-    assert_turbo_stream_broadcasts :rooms, count: 0 do
-      put rooms_closed_url(rooms(:designers)), params: { room: { name: "New Name" } }
+    perform_enqueued_jobs do
+      assert_turbo_stream_broadcasts :rooms, count: 0 do
+        put rooms_closed_url(rooms(:designers)), params: { room: { name: "New Name" } }
+      end
     end
 
     assert_response :forbidden

--- a/test/controllers/rooms/opens_controller_test.rb
+++ b/test/controllers/rooms/opens_controller_test.rb
@@ -27,8 +27,10 @@ class Rooms::OpensControllerTest < ActionDispatch::IntegrationTest
   test "only admins or creators can update" do
     sign_in :jz
 
-    assert_turbo_stream_broadcasts :rooms, count: 0 do
-      put rooms_open_url(rooms(:hq)), params: { room: { name: "New Name" } }
+    perform_enqueued_jobs do
+      assert_turbo_stream_broadcasts :rooms, count: 0 do
+        put rooms_open_url(rooms(:hq)), params: { room: { name: "New Name" } }
+      end
     end
 
     assert_response :forbidden
@@ -36,8 +38,10 @@ class Rooms::OpensControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "update" do
-    assert_turbo_stream_broadcasts :rooms, count: 1 do
-      put rooms_open_url(rooms(:pets)), params: { room: { name: "New Name" } }
+    perform_enqueued_jobs do
+      assert_turbo_stream_broadcasts :rooms, count: 1 do
+        put rooms_open_url(rooms(:pets)), params: { room: { name: "New Name" } }
+      end
     end
 
     assert_redirected_to room_url(rooms(:pets))


### PR DESCRIPTION
- Fixes #19 

-  Moved the broadcast operation to a background job (`Room::BroadcastUpdateJob`) that:

    - Processes members asynchronously via Resque
    - Uses `find_each` to batch 1000 records at a time
    - Implements smart HTML caching to reduce rendering (caches by involvement/unread/notification state)
    - Returns immediately to avoid request timeouts