### PR TITLE
Add admin-only room URL slugs

### DIFF
--- a/app/constraints/room_slug_constraint.rb
+++ b/app/constraints/room_slug_constraint.rb
@@ -1,0 +1,8 @@
+class RoomSlugConstraint
+  def matches?(request)
+    slug = request.params[:slug].to_s.strip.downcase
+    return false if slug.blank?
+
+    Room.active.exists?(slug: slug)
+  end
+end

--- a/app/views/rooms/layouts/_form.html.erb
+++ b/app/views/rooms/layouts/_form.html.erb
@@ -18,6 +18,24 @@
 
   <hr class="margin-block borderless">
 
+  <% if Current.user.administrator? %>
+    <div class="pad-inline">
+      <label class="flex flex-column gap-half txt-large" for="room_slug">
+        <span>Custom URL slug (optional)</span>
+        <%= text_field_tag "room[slug]", room.slug, id: "room_slug", class: "input full-width",
+              placeholder: "e.g. founders-lounge",
+              pattern: "[a-z0-9](?:[a-z0-9-]*[a-z0-9])",
+              maxlength: 80,
+              inputmode: "lowercase",
+              spellcheck: false,
+              data: { action: "keydown.enter->form#submit:prevent" } %>
+        <small class="txt-secondary">Accessible at /<%= room.slug.presence || "your-slug" %>. Only letters, numbers, and hyphens; no leading/trailing hyphen.</small>
+      </label>
+    </div>
+
+    <hr class="margin-block borderless">
+  <% end %>
+
   <section class="room-access margin-block pad-inline fill-shade border-radius">
     <%= yield form %>
   </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
+  # Top-level room slug routing (must come before other catch-alls that could conflict)
+  constraints(RoomSlugConstraint.new) do
+    get "/:slug", to: "rooms#show", as: :room_slug
+  end
+
   # Redirect www.smallbets.com to smallbets.com
   constraints(host: /^www\.smallbets\.com/) do
     match "(*any)", to: redirect { |params, request|

--- a/db/migrate/20250928120000_add_slug_to_rooms.rb
+++ b/db/migrate/20250928120000_add_slug_to_rooms.rb
@@ -1,0 +1,6 @@
+class AddSlugToRooms < ActiveRecord::Migration[7.1]
+  def change
+    add_column :rooms, :slug, :string
+    add_index  :rooms, :slug, unique: true, where: "slug IS NOT NULL"
+  end
+end


### PR DESCRIPTION
Add optional URL slugs for rooms, allowing administrators to create user-friendly URLs like `/:slug` for direct room access.

This feature provides a more memorable and shareable way to access specific chat rooms, moving beyond numerical IDs, while ensuring only administrators can manage these slugs to maintain control and prevent conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-7cf31037-8088-454d-91df-8664a6967e1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7cf31037-8088-454d-91df-8664a6967e1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

