### PR TITLE
Link room sidebar to slug url

### DIFF
--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -1,6 +1,7 @@
 module RoomsHelper
   def link_to_room(room, **attributes, &)
-    link_to room_path(room), **attributes, data: {
+    path = room.slug.present? ? room_slug_path(room.slug) : room_path(room)
+    link_to path, **attributes, data: {
       rooms_list_target: "room", room_id: room.id, badge_dot_target: "unread"
     }.merge(attributes.delete(:data) || {}), &
   end


### PR DESCRIPTION
Update `link_to_room` helper to use the room's slug in the URL when available, providing more user-friendly links in the rooms sidebar.

---
<a href="https://cursor.com/background-agent?bcId=bc-b14dec48-1f3f-471f-9d1d-c966be78767a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b14dec48-1f3f-471f-9d1d-c966be78767a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

