### PR TITLE
Resolve room by slug if available

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -10,6 +10,13 @@ class RoomsController < ApplicationController
   end
 
   def show
+    # Redirect to canonical slug URL when available, unless viewing a specific message
+    if params[:message_id].blank? && @room.slug.present? && params[:slug].blank?
+      target = room_slug_url(@room.slug)
+      target = target + "?" + request.query_string if request.query_string.present?
+      return redirect_to(target)
+    end
+
     @messages = Bookmark.populate_for(find_messages)
   end
 

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,7 +1,10 @@
 class WelcomeController < ApplicationController
   def show
     if Current.user.rooms.any?
-      redirect_to room_url(landing_room)
+      room = landing_room
+      target = room.slug.present? ? room_slug_url(room.slug) : room_url(room)
+      target = target + "?" + request.query_string if request.query_string.present?
+      redirect_to target
     else
       render
     end


### PR DESCRIPTION
Redirect room URLs to their canonical slug when available to ensure chat rooms open at the slug URL instead of `/rooms/:id`.

---
<a href="https://cursor.com/background-agent?bcId=bc-50cfff0e-c075-4876-8036-3bea0a4d1912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-50cfff0e-c075-4876-8036-3bea0a4d1912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

